### PR TITLE
(maint) Remove POT-Creation-Date from generated messages.pot file

### DIFF
--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -32,6 +32,7 @@ locales/messages.pot: $(SRC_FILES)
 				   -ktru:1 -ki18n/tru:1                                      \
 	               --add-comments -o $tmp -f -;                              \
 	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                       \
+	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp;       \
 	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then             \
 		mv $tmp $@;                                                          \
 	else                                                                     \


### PR DESCRIPTION
This timestamp isn't really useful for connecting messages.pot contents
with a version of code, and causes spurious merge conflicts between
almost any two concurrent topic branches.
