### PR TITLE
(maint) Prep clj-i18n for initial clojars release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,21 +1,16 @@
-(defn deploy-info
-  [url]
-  {:url url
-   :username :env/nexus_jenkins_username
-   :password :env/nexus_jenkins_password
-   :sign-releases false})
+(defproject puppetlabs/i18n "0.2.1-SNAPSHOT"
+  :description "Clojure i18n library"
+  :url "http://github.com/puppetlabs/clj-i18n"
+  :license {:name "Apache License, Version 2.0"
+            :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
-(defproject puppetlabs/i18n "0.3.0-SNAPSHOT"
-  :description "FIXME: write description"
-  :url "http://example.com/FIXME"
-  :license {:name "Eclipse Public License"
-            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.6.0"]]
+
   :main puppetlabs.i18n.main
   :aot [puppetlabs.i18n.main]
 
-  :repositories [["releases" "http://nexus.delivery.puppetlabs.net/content/repositories/releases/"]
-                 ["snapshots"  "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/"]]
-
-  :deploy-repositories [["releases" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/releases/")]
-                        ["snapshots" ~(deploy-info "http://nexus.delivery.puppetlabs.net/content/repositories/snapshots/")]])
+  :deploy-repositories [["releases" {:url "https://clojars.org/repo"
+                                     :username :env/clojars_jenkins_username
+                                     :password :env/clojars_jenkins_password
+                                     :sign-releases false}]])


### PR DESCRIPTION
This commit sets the version back to `0.2.1-SNAPSHOT` so that we can
release `0.2.1` to Clojars and fixes up some of the other miscellaneous
fields in the project.clj like `:url` and `:license`. This commit also
changes the repositories so that our Jenkins job will deploy to Clojars.