### PR TITLE
Add support for pluralization string extraction and use

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,19 +22,27 @@ for example log messages, and `tru` for messages that will be shown to the
 current user, for example an error that happened processing a web request.
 
 When you require `puppetlabs.i18n.core` into your namespace, you *must*
-call it either `trs`/`tru` or `i18n/trs`/`i18n/tru` (these are the names
-that `xgettext` will look for when it extracts strings) Typically, you
+call it either `trs`/`tru`/`trun`/`trsn` or
+`i18n/trs`/`i18n/tru`/`i18n/trun`/`i18n/trsn` (these are the names that
+`xgettext` will look for when it extracts strings) Typically, you
 would have this in your namespace declaration
 
     (ns puppetlabs.myproject
-      (:require [puppetlabs.i18n.core :as i18n :refer [trs tru]]))
+      (:require [puppetlabs.i18n.core :as i18n :refer [trs trsn tru trun]]))
 
 You use `trs`/`tru` very similar to how you use `format`, except that the
 format string must be a valid
 [`java.text.MessageFormat`](https://docs.oracle.com/javase/8/docs/api/java/text/MessageFormat.html)
 pattern. For example, you would write
 
-    (println (trs "It takes {0} women {1} months to have a child" 3 9))
+    (println (trs "It takes {0} software engineers {1} hours to change a light bulb" 3 9))
+
+`trsn`/`trun` are similar to `trs`/`tru` except that they support pluralization
+of strings.  The first argument is the singular version of the string, the second
+argument must be the plural form of the string.  The third argument is the count value
+to determine the level of pluralization.  Any additional arguments will be used for additional formatting
+
+    (println (trsn "We found one cute puppy" "We found {0} cute puppies" 5))
 
 ### Comments for translators
 
@@ -152,7 +160,8 @@ the following:
 1. For each of the additional locales, create a message catalog. It will
    generally be easiest to base that message catalog on properties files
    rather than on `.po` files. If you added the `eo` locale, you need to
-   create a file `test/<package path>/Messages_eo.properties`
+   create a file `test/<package path>/Messages_eo.properties`.  Note that
+   pluralization is not currently supported in properties files.
 1. Use those additional locales in your tests. The `test/` directory of
    this library has an example of that in the `test-tru` test in
    `core_test.clj`.

--- a/locales/de.po
+++ b/locales/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
-"POT-Creation-Date: 2016-03-10 15:28-0800\n"
+"POT-Creation-Date: \n"
 "PO-Revision-Date: 2015-03-26 17:16-0700\n"
 "Last-Translator: David Lutterkort <lutter@watzmann.net>\n"
 "Language-Team: German\n"
@@ -23,9 +23,15 @@ msgid "Welcome! This is localized"
 msgstr "Willkommen ! Draußen nur Kännchen"
 
 #: src/puppetlabs/i18n/main.clj:22
+msgid "There is one bottle of beer on the wall."
+msgid_plural "There are {0} bottles of beer on the wall."
+msgstr[0] "Es gibt eine Flasche Bier an der Wand."
+msgstr[1] "Es gibt {0} Flaschen Bier an der Wand."
+
+#: src/puppetlabs/i18n/main.clj:27
 msgid "It took {0} programmers {1} months to implement this"
 msgstr "{0} Programmierer brauchten {1} Monat(e) um das zu implementieren"
 
-#: src/puppetlabs/i18n/main.clj:27
+#: src/puppetlabs/i18n/main.clj:32
 msgid "There are {0,number,integer} bicycles in Beijing"
 msgstr "In Peking gibt es {0,number,integer} Fahrräder"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: puppetlabs.i18n \n"
 "Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
-"POT-Creation-Date: 2016-03-10 15:28-0800\n"
+"POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,6 +16,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #. Very simple localization
 #: src/puppetlabs/i18n/main.clj:18
@@ -23,9 +24,15 @@ msgid "Welcome! This is localized"
 msgstr ""
 
 #: src/puppetlabs/i18n/main.clj:22
+msgid "There is one bottle of beer on the wall."
+msgid_plural "There are {0} bottles of beer on the wall."
+msgstr[0] ""
+msgstr[1] ""
+
+#: src/puppetlabs/i18n/main.clj:27
 msgid "It took {0} programmers {1} months to implement this"
 msgstr ""
 
-#: src/puppetlabs/i18n/main.clj:27
+#: src/puppetlabs/i18n/main.clj:32
 msgid "There are {0,number,integer} bicycles in Beijing"
 msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
             :url "http://www.apache.org/licenses/LICENSE-2.0"}
 
   :pedantic? :abort
-  :dependencies [[org.clojure/clojure "1.6.0"]]
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [org.gnu.gettext/libintl "0.18.3"]]
 
   :main puppetlabs.i18n.main
   :aot [puppetlabs.i18n.main]

--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -28,10 +28,10 @@ locales/messages.pot: $(SRC_FILES)
 	               --package-name "$(PACKAGE)"                               \
 	               --package-version "$(PACKAGE_VERSION)"                    \
 	               --msgid-bugs-address "docs@puppetlabs.com"                \
-				   -ktrs:1 -ki18n/trs:1                                      \
-				   -ktru:1 -ki18n/tru:1                                      \
-				   -ktrun:1,2 -ki18n/trun:1,2                                \
-				   -ktrsn:1,2 -ki18n/trsn:1,2                                \
+	               -ktrs:1 -ki18n/trs:1                                      \
+	               -ktru:1 -ki18n/tru:1                                      \
+	               -ktrun:1,2 -ki18n/trun:1,2                                \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                                \
 	               --add-comments -o $tmp -f -;                              \
 	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                       \
 	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp;       \

--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -30,6 +30,8 @@ locales/messages.pot: $(SRC_FILES)
 	               --msgid-bugs-address "docs@puppetlabs.com"                \
 				   -ktrs:1 -ki18n/trs:1                                      \
 				   -ktru:1 -ki18n/tru:1                                      \
+				   -ktrun:1,2 -ki18n/trun:1,2                                \
+				   -ktrsn:1,2 -ki18n/trsn:1,2                                \
 	               --add-comments -o $tmp -f -;                              \
 	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                       \
 	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp;       \

--- a/src/puppetlabs/i18n/main.clj
+++ b/src/puppetlabs/i18n/main.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.i18n.main
   "Some I18N examples"
   (:gen-class)
-  (:require [puppetlabs.i18n.core :as i18n :refer [tru trs]]))
+  (:require [puppetlabs.i18n.core :as i18n :refer [tru trs trsn]]))
 
 ;; Some simple examples of using tru/trs
 ;; The unit tests rely on the message catalog and translation generated for
@@ -17,10 +17,17 @@
   ;; Very simple localization
   (println (trs "Welcome! This is localized"))
 
+  ;; Very simple plural system localization
+  (doseq [beers (range 5 0 -1)]
+    (println (trsn "There is one bottle of beer on the wall."
+                   "There are {0} bottles of beer on the wall."
+                   beers)))
+
   ;; String with arguments
-  (let [nprog 3 nmonths 5]
+  (let [nprog 3
+        nmonths 5]
     (println (i18n/tru "It took {0} programmers {1} months to implement this"
-                      nprog nmonths)))
+                       nprog nmonths)))
 
   ;; String with special formatting
   (let [nbikes 9000000]

--- a/test/puppetlabs/i18n/core_test.clj
+++ b/test/puppetlabs/i18n/core_test.clj
@@ -13,6 +13,15 @@
 (def welcome_de "Willkommen ! Draußen nur Kännchen")
 (def welcome_eo "Welcome_pseudo_localized")
 
+(def one_bottle "There is one bottle of beer on the wall.")
+(def n_bottles "There are {0} bottles of beer on the wall.")
+(def one_bottle_en "There is one bottle of beer on the wall.")
+(def one_bottle_de "Es gibt eine Flasche Bier an der Wand.")
+
+(def six_bottle_en "There are 6 bottles of beer on the wall.")
+(def six_bottle_de "Es gibt 6 Flaschen Bier an der Wand.")
+
+
 (deftest handling-of-user-locale
   (testing "user-locale defaults to system-locale"
     (is (= (system-locale) (user-locale))))
@@ -37,12 +46,30 @@
     (with-user-locale eo
       (is (= welcome_eo (tru welcome_en))))))
 
+(deftest test-trun
+  (testing "trun with no user locale"
+    (is (= one_bottle_en (trun one_bottle n_bottles 1)))
+    (is (= six_bottle_en (trun one_bottle n_bottles 6))))
+  (testing "trun in German"
+    (with-user-locale de (is (= one_bottle_de (trun one_bottle n_bottles 1))))
+    (with-user-locale de (is (= six_bottle_de (trun one_bottle n_bottles 6))))))
+
+
 (deftest test-trs
   (testing "trs with no user locale"
     (is (= welcome_en (trs welcome_en))))
   (testing "trs with a user locale"
     (with-user-locale de
       (is (= welcome_en (trs welcome_en))))))
+
+
+(deftest test-trsn
+  (testing "trun with no user locale"
+    (is (= one_bottle_en (trsn one_bottle n_bottles 1)))
+    (is (= six_bottle_en (trsn one_bottle n_bottles 6))))
+  (testing "trun with a user locale"
+    (with-user-locale de (is (= one_bottle_en (trsn one_bottle n_bottles 1))))
+    (with-user-locale de (is (= six_bottle_en (trsn one_bottle n_bottles 6))))))
 
 ;;
 ;; Helper files in dev-resources; they have the same format as the


### PR DESCRIPTION
This adds two new functions trun and trsn that support pluralization.  They mirror the
ngettext function in behavior, while keeping the convention of java formatting.

Examples and tests were updated as well.