### PR TITLE
(maint) Fix lookup-plural function

### DIFF
--- a/src/puppetlabs/i18n/core.clj
+++ b/src/puppetlabs/i18n/core.clj
@@ -193,8 +193,8 @@
         (gnu.gettext.GettextResource/ngettext bundle msgid msgid-plural count)
         (catch java.util.MissingResourceException e
           ;; no key for msg
-          msgid))
-      msgid)))
+          (if (= count 1) msgid msgid-plural)))
+      (if (= count 1) msgid msgid-plural))))
 
 
 (defn fmt


### PR DESCRIPTION
This fixes the ```lookup-plural``` function to return the plural message id in case the translation is not found and the count is not equal to 1.
Previously it always returned the singular message id.