### PR TITLE
(INTL-1) Support for multiple packages in locales.clj

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,16 @@ On Red Hat-based operating systems, including Fedora, install gettext via
 
 1. In your `project.clj`, add `puppetlabs/i18n` to the `:dependencies` and to
    the `plugins`
-1. Run `lein i18n init`. This will
+2. Run `lein i18n init`. This will
    * put a `Makefile.i18n` into `dev-resources/` in your project and include it
      into an existing toplevel `Makefile` resp. create a new one that does that.
      You should check these files into you source control system.
    * add hooks to the `compile` task that will refresh i18n data (equivalent of
      running `make i18n`)
+3. If there are namespaces/packages in your project with names which do not
+   start with a prefix derived from the project name, you'll need to list all
+   of your namespaces/package name prefixes in the `PACKAGES` variable in the
+   toplevel `Makefile` before the inclusion of the `dev-resources/Makefile.i18n`
 
 This setup will ensure that the file `locales/messages.pot` and the translations
 in `locales/LANG.po` are updated every time you compile your project. Compiling

--- a/dev-resources/test-locales/conflicting-de.clj
+++ b/dev-resources/test-locales/conflicting-de.clj
@@ -1,0 +1,7 @@
+;; This locales.clj sample is deliberately conflicting with the de-ru-es.clj.
+;; It is used by the tests in core_test.clj.
+{
+  :locales #{"de"}
+  :package "example.i18n"
+  :bundle  "alternate.i18n.Messages"
+}

--- a/dev-resources/test-locales/de-ru-es.clj
+++ b/dev-resources/test-locales/de-ru-es.clj
@@ -1,5 +1,6 @@
-;; This is a sample of the locales.clj file that the Makefile generates
-;; It is used by the tests in core_test.clj
+;; This is a sample of the locales.clj file that the old version of
+;; the Makefile used to generate.
+;; It is used by the tests in core_test.clj.
 {
   :locales #{"de" "es" "ru"}
   :package "example.i18n"

--- a/dev-resources/test-locales/fr-it.clj
+++ b/dev-resources/test-locales/fr-it.clj
@@ -1,5 +1,6 @@
-;; This is a sample of the locales.clj file that the Makefile generates
-;; It is used by the tests in core_test.clj
+;; This is a sample of the locales.clj file that the old version of
+;; the Makefile used to generate.
+;; It is used by the tests in core_test.clj.
 {
   :locales #{"it" "fr"}
   :package "other.i18n"

--- a/dev-resources/test-locales/merge-eo.clj
+++ b/dev-resources/test-locales/merge-eo.clj
@@ -1,7 +1,6 @@
 ;; This has the same package as de-es-ru.clj which means we will merge the
-;; locales from both files
-;; This is mainly useful for tests where it lets us add a fake message
-;; catalog that is not available during normal use
+;; locales from both files.
+;; It is used by the tests in core_test.clj.
 {
   :locales #{"eo"}
   :package "example.i18n"

--- a/dev-resources/test-locales/multi-pacakge-es.clj
+++ b/dev-resources/test-locales/multi-pacakge-es.clj
@@ -1,0 +1,8 @@
+;; This is a sample of the locales.clj file that the current version fo the
+;; Makefile generates.
+;; It is used by the tests in core_test.clj.
+{
+  :locales  #{"es"}
+  :packages ["example.i18n" "alternate.i18n"]
+  :bundle   "multi_package.i18n.Messages"
+}

--- a/locales/de.po
+++ b/locales/de.po
@@ -6,7 +6,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: 2015-03-26 17:16-0700\n"
 "Last-Translator: David Lutterkort <lutter@watzmann.net>\n"
@@ -28,10 +28,10 @@ msgid_plural "There are {0} bottles of beer on the wall."
 msgstr[0] "Es gibt eine Flasche Bier an der Wand."
 msgstr[1] "Es gibt {0} Flaschen Bier an der Wand."
 
-#: src/puppetlabs/i18n/main.clj:27
+#: src/puppetlabs/i18n/main.clj:29
 msgid "It took {0} programmers {1} months to implement this"
 msgstr "{0} Programmierer brauchten {1} Monat(e) um das zu implementieren"
 
-#: src/puppetlabs/i18n/main.clj:32
+#: src/puppetlabs/i18n/main.clj:34
 msgid "There are {0,number,integer} bicycles in Beijing"
 msgstr "In Peking gibt es {0,number,integer} Fahrräder"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Puppet Labs <docs@puppetlabs.com>
+# Copyright (C) YEAR Puppet <docs@puppet.com>
 # This file is distributed under the same license as the puppetlabs.i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
@@ -7,7 +7,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: puppetlabs.i18n \n"
-"Report-Msgid-Bugs-To: docs@puppetlabs.com\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
@@ -29,10 +29,10 @@ msgid_plural "There are {0} bottles of beer on the wall."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/puppetlabs/i18n/main.clj:27
+#: src/puppetlabs/i18n/main.clj:29
 msgid "It took {0} programmers {1} months to implement this"
 msgstr ""
 
-#: src/puppetlabs/i18n/main.clj:32
+#: src/puppetlabs/i18n/main.clj:34
 msgid "There are {0,number,integer} bicycles in Beijing"
 msgstr ""

--- a/src/leiningen/i18n.clj
+++ b/src/leiningen/i18n.clj
@@ -53,10 +53,12 @@
   (let [dest (path-join (dev-resources-dir project) "Makefile.i18n")
         makefile (io/resource "leiningen/i18n/Makefile")]
     (spit (io/as-file dest)
-          (clojure.string/replace
+          (clojure.string/replace-first
            (slurp makefile)
-           #"PACKAGE=.*"
-           (str "PACKAGE=" (bundle-package-name project))))))
+           ; use RegExp's m flag - (?m) - so that ^/$ matach start/end of line rather than
+           ; start/end of the entire string
+           #"(?m)^BUNDLE=.*$"
+           (str "BUNDLE=" (bundle-package-name project))))))
 
 (defn project-file
   "Construct a path in the project's root by appending rest to it and

--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -8,72 +8,90 @@
 # have messages without any further effort
 MESSAGE_LOCALE=en
 
-# The name of the package into which tranlsations will be placed
-PACKAGE=puppetlabs.i18n
+# The name of the package into which the translations bundle will be placed
+BUNDLE=puppetlabs.i18n
+# The list of names of packages covered by the translation bundle;
+# by default it contains a single package - the same where the translations
+# bundle itself is placed - but this can be overridden - preferably in
+# the top level Makefile
+PACKAGES?=$(BUNDLE)
 LOCALES=$(basename $(notdir $(wildcard locales/*.po)))
-PACKAGE_DIR=$(subst .,/,$(PACKAGE))
-BUNDLE_FILES=$(patsubst %,resources/$(PACKAGE_DIR)/Messages_%.class,$(LOCALES) $(MESSAGE_LOCALE))
-SRC_FILES=$(shell find src -name \*.clj)
+BUNDLE_DIR=$(subst .,/,$(BUNDLE))
+BUNDLE_FILES=$(patsubst %,resources/$(BUNDLE_DIR)/Messages_%.class,$(MESSAGE_LOCALE) $(LOCALES))
+FIND_SOURCES=find src -name \*.clj
+LOCALES_CLJ=resources/locales.clj
+define LOCALES_CLJ_CONTENTS
+{
+  :locales  #{$(patsubst %,"%",$(MESSAGE_LOCALE) $(LOCALES))}
+  :packages [$(patsubst %,"%",$(PACKAGES))]
+  :bundle   $(patsubst %,"%",$(BUNDLE).Messages)
+}
+endef
+export LOCALES_CLJ_CONTENTS
 
-i18n: setup update-pot msgfmt
+
+i18n: update-pot msgfmt
 
 # Update locales/messages.pot
 update-pot: locales/messages.pot
 
-locales/messages.pot: $(SRC_FILES)
-	@tmp=$(mktemp $@.tmp.XXXX);                                              \
-	find src -name \*.clj                                                    \
-	    | xgettext --from-code=UTF-8 --language=lisp                         \
-	               --copyright-holder 'Puppet Labs <docs@puppetlabs.com>' -F \
-	               --package-name "$(PACKAGE)"                               \
-	               --package-version "$(PACKAGE_VERSION)"                    \
-	               --msgid-bugs-address "docs@puppetlabs.com"                \
-	               -ktrs:1 -ki18n/trs:1                                      \
-	               -ktru:1 -ki18n/tru:1                                      \
-	               -ktrun:1,2 -ki18n/trun:1,2                                \
-	               -ktrsn:1,2 -ki18n/trsn:1,2                                \
-	               --add-comments -o $tmp -f -;                              \
-	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                       \
-	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp;       \
-	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then             \
-		mv $tmp $@;                                                          \
-	else                                                                     \
-		rm $tmp;                                                             \
+locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
+	@tmp=$(mktemp $@.tmp.XXXX);                                        \
+	$(FIND_SOURCES)                                                    \
+	    | xgettext --from-code=UTF-8 --language=lisp                   \
+	               --copyright-holder 'Puppet <docs@puppet.com>' -F    \
+	               --package-name "$(BUNDLE)"                          \
+	               --package-version "$(BUNDLE_VERSION)"               \
+	               --msgid-bugs-address "docs@puppet.com"              \
+	               -ktrs:1 -ki18n/trs:1                                \
+	               -ktru:1 -ki18n/tru:1                                \
+	               -ktrun:1,2 -ki18n/trun:1,2                          \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                          \
+	               --add-comments -o $tmp -f -;                        \
+	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                 \
+	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp; \
+	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then       \
+	    mv $tmp $@;                                                    \
+	else                                                               \
+	    rm $tmp;                                                       \
 	fi
 
 # Run msgfmt over all .po files to generate Java resource bundles
-msgfmt: $(BUNDLE_FILES)
-	@(printf '{\n  :locales #{'; \
-	  printf "\"%s\"" $(MESSAGE_LOCALE); \
-	  for l in $(LOCALES); do printf " \"%s\"" $$l; done; \
-	  printf '}\n'; \
-	  printf '  :package "$(PACKAGE)"\n'; \
-	  printf '  :bundle  "$(PACKAGE).Messages"\n}\n') > resources/locales.clj
+# and create the locales.clj file
+msgfmt: $(BUNDLE_FILES) $(LOCALES_CLJ)
 
-resources/$(PACKAGE_DIR)/Messages_%.class: locales/%.po
-	msgfmt --java2 -d resources -r $(PACKAGE).Messages -l $$(basename $< .po) $<
+# force rebuild of locales.clj if its contents is not the
+# the desired one
+ifneq ($(shell cat $(LOCALES_CLJ) 2> /dev/null),$(shell echo '$(subst ','\'',$(LOCALES_CLJ_CONTENTS))'))
+.PHONY: $(LOCALES_CLJ)
+endif
+$(LOCALES_CLJ): | resources
+	@echo "Writing $@"
+	@echo "$$LOCALES_CLJ_CONTENTS" > $@
 
-resources/$(PACKAGE_DIR)/Messages_$(MESSAGE_LOCALE).class: locales/messages.pot
-	msgfmt --java2 -d resources -r $(PACKAGE).Messages -l $(MESSAGE_LOCALE) $<
+resources/$(BUNDLE_DIR)/Messages_%.class: locales/%.po | resources
+	msgfmt --java2 -d resources -r $(BUNDLE).Messages -l $(*F) $<
+
+resources/$(BUNDLE_DIR)/Messages_$(MESSAGE_LOCALE).class: locales/messages.pot | resources
+	msgfmt --java2 -d resources -r $(BUNDLE).Messages -l $(MESSAGE_LOCALE) $<
 
 # Translators use this when they update translations; this copies any
 # changes in the pot file into their language-specific po file
 locales/%.po: locales/messages.pot
-	@if [ -f $@ ]; then												\
-		msgmerge -U $@ $< && touch $@; 								\
-	else															\
-		touch $@ && 												\
-		msginit --no-translator -l $$(basename $@ .po) -o $@ -i $<;	\
+	@if [ -f $@ ]; then                                           \
+	    msgmerge -U $@ $< && touch $@;                            \
+	else                                                          \
+	    touch $@ && msginit --no-translator -l $(*F) -o $@ -i $<; \
 	fi
+
+resources locales:
+	@mkdir $@
 
 help:
 	$(info $(HELP))
 	@echo
 
-setup:
-	@mkdir -p locales
-
-.PHONY:setup help
+.PHONY: help
 
 define HELP
 This Makefile assists in handling i18n related tasks during development. Files


### PR DESCRIPTION
Prior to this commit the ```:package``` key in the ```locales.clj``` file as generated by the Makefile was set to a value derived from the project name.
This didn't work at least for the following projects:

* [puppetlabs/pcp-common](https://github.com/puppetlabs/clj-pcp-common)
* [puppetlabs/pcp-client](https://github.com/puppetlabs/clj-pcp-client)

which don't use the assumed prefixes of ```puppetlabs.pcp_common``` and ```puppetlabs.pcp_client``` respectively for their namespaces but rather define different namespaces under the common root of ```puppetlabs.pcp```.
To be able to support that, this patch redefines the structure of the ```locales.clj``` such that it can now contain the ```:packages``` key (as opposed to the original ```:package```) which is expected to contain a collection of packages covered by the associated ```:bundle```.

The Makefile is updated to support this new structure. There are couple of user impacting changes:

* the Makefile's ```PACKAGE``` variable is renamed to ```BUNDLE```
* a new variable named ```PACKAGES``` (note the plural) is introduced; it defines the list of packages supported by the resource bundle; by default it is set to ```$(BUNDLE)``` to mimic the original behavior, but it can be overridden by the user should the project need it