### PR TITLE
(maint) Makefile fixes

### DIFF
--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -36,25 +36,28 @@ i18n: update-pot msgfmt
 update-pot: locales/messages.pot
 
 locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
-	@tmp=$(mktemp $@.tmp.XXXX);                                        \
-	$(FIND_SOURCES)                                                    \
-	    | xgettext --from-code=UTF-8 --language=lisp                   \
-	               --copyright-holder 'Puppet <docs@puppet.com>' -F    \
-	               --package-name "$(BUNDLE)"                          \
-	               --package-version "$(BUNDLE_VERSION)"               \
-	               --msgid-bugs-address "docs@puppet.com"              \
-	               -ktrs:1 -ki18n/trs:1                                \
-	               -ktru:1 -ki18n/tru:1                                \
-	               -kmark:1 -ki18n/mark:1                              \
-	               -ktrun:1,2 -ki18n/trun:1,2                          \
-	               -ktrsn:1,2 -ki18n/trsn:1,2                          \
-	               --add-comments -o $tmp -f -;                        \
-	sed -i -e 's/charset=CHARSET/charset=UTF-8/' $tmp;                 \
-	sed -i -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $tmp; \
-	if ! diff -q -I POT-Creation-Date $tmp $@ >& /dev/null; then       \
-	    mv $tmp $@;                                                    \
-	else                                                               \
-	    rm $tmp;                                                       \
+	@tmp=$$(mktemp $@.tmp.XXXX);                                            \
+	$(FIND_SOURCES)                                                         \
+	    | xgettext --from-code=UTF-8 --language=lisp                        \
+	               --copyright-holder='Puppet <docs@puppet.com>'            \
+	               --package-name="$(BUNDLE)"                               \
+	               --package-version="$(BUNDLE_VERSION)"                    \
+	               --msgid-bugs-address="docs@puppet.com"                   \
+	               -k                                                       \
+	               -kmark:1 -ki18n/mark:1                                   \
+	               -ktrs:1 -ki18n/trs:1                                     \
+	               -ktru:1 -ki18n/tru:1                                     \
+	               -ktrun:1,2 -ki18n/trun:1,2                               \
+	               -ktrsn:1,2 -ki18n/trsn:1,2                               \
+	               --add-comments --sort-by-file                            \
+	               -o $$tmp -f -;                                           \
+	sed -i.bak -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
+	sed -i.bak -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
+	rm -f $$tmp.bak;                                                        \
+	if ! diff -q -I POT-Creation-Date $$tmp $@ >& /dev/null; then           \
+	    mv $$tmp $@;                                                        \
+	else                                                                    \
+	    rm $$tmp; touch $@;                                                 \
 	fi
 
 # Run msgfmt over all .po files to generate Java resource bundles


### PR DESCRIPTION
This commit introduces a couple of fixes for problems in the Makefile:
* the dollar characters in the shell receipt for extracting the messages to be localized are now properly escaped
* the sed command is now invoked in a way that works on both Linux and Mac OS X (the previous way didn't work on Mac OS X due to a difference in handling of the sed's `-i` option argument between Linux and Mac OS X)
* the `-k` option is now passed to the `xgettext` to suppress accidental localization of clojure forms resembling some of the lisp forms localized by default
* the `-F` option is passed as `--sort-by-file` to `xgettext` to be more self explanatory
* the `messages.pot` file is touched even if not changed in case it is older than some of the clojure sources so that it is considered up-to-date the next time make is executed