### PR TITLE
(ORCH-1232) Add a standard function for marking strings for extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ patterns and need to be escaped with another single quote:
     ;; The following will produce "He's going to the store"
     (trs "He''s going to the store")
 
+### Separating message extraction from translation
+
+In some cases, messages need to be generated separately from when they're
+translated; this is common in specialized `def` forms or when defining a
+constant for reuse. In that case, use the `mark` macro to mark strings for
+xgettext extraction, and the standard `trs`/`tru` at the translation site.
+
 ### Development tools
 
 Extracting messages and building ResourceBundles requires the command line tools

--- a/locales/de.po
+++ b/locales/de.po
@@ -17,21 +17,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+#: src/puppetlabs/i18n/main.clj:6
+msgid "I do not speak German"
+msgstr "Ich spreche kein Deutsch"
+
 #. Very simple localization
-#: src/puppetlabs/i18n/main.clj:18
+#: src/puppetlabs/i18n/main.clj:21
 msgid "Welcome! This is localized"
 msgstr "Willkommen ! Draußen nur Kännchen"
 
-#: src/puppetlabs/i18n/main.clj:22
+#: src/puppetlabs/i18n/main.clj:28
 msgid "There is one bottle of beer on the wall."
 msgid_plural "There are {0} bottles of beer on the wall."
 msgstr[0] "Es gibt eine Flasche Bier an der Wand."
 msgstr[1] "Es gibt {0} Flaschen Bier an der Wand."
 
-#: src/puppetlabs/i18n/main.clj:29
+#: src/puppetlabs/i18n/main.clj:35
 msgid "It took {0} programmers {1} months to implement this"
 msgstr "{0} Programmierer brauchten {1} Monat(e) um das zu implementieren"
 
-#: src/puppetlabs/i18n/main.clj:34
+#: src/puppetlabs/i18n/main.clj:40
 msgid "There are {0,number,integer} bicycles in Beijing"
 msgstr "In Peking gibt es {0,number,integer} Fahrräder"
+
+#~ msgid "This is another test string"
+#~ msgstr "german german german german german"

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -18,21 +18,25 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
+#: src/puppetlabs/i18n/main.clj:6
+msgid "I do not speak German"
+msgstr ""
+
 #. Very simple localization
-#: src/puppetlabs/i18n/main.clj:18
+#: src/puppetlabs/i18n/main.clj:21
 msgid "Welcome! This is localized"
 msgstr ""
 
-#: src/puppetlabs/i18n/main.clj:22
+#: src/puppetlabs/i18n/main.clj:28
 msgid "There is one bottle of beer on the wall."
 msgid_plural "There are {0} bottles of beer on the wall."
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/puppetlabs/i18n/main.clj:29
+#: src/puppetlabs/i18n/main.clj:35
 msgid "It took {0} programmers {1} months to implement this"
 msgstr ""
 
-#: src/puppetlabs/i18n/main.clj:34
+#: src/puppetlabs/i18n/main.clj:40
 msgid "There are {0,number,integer} bicycles in Beijing"
 msgstr ""

--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -45,6 +45,7 @@ locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
 	               --msgid-bugs-address "docs@puppet.com"              \
 	               -ktrs:1 -ki18n/trs:1                                \
 	               -ktru:1 -ki18n/tru:1                                \
+	               -kmark:1 -ki18n/mark:1                              \
 	               -ktrun:1,2 -ki18n/trun:1,2                          \
 	               -ktrsn:1,2 -ki18n/trsn:1,2                          \
 	               --add-comments -o $tmp -f -;                        \

--- a/src/puppetlabs/i18n/core.clj
+++ b/src/puppetlabs/i18n/core.clj
@@ -256,6 +256,10 @@
   [& args]
   `(translate-plural ~(namespace-munge *ns*) (system-locale) ~@args))
 
+;; Mark a message for extraction, without translation. This is useful when
+;; strings are defined at compile time but need to be translated at run time.
+(def mark identity)
+
 ;;
 ;; Ring middleware for language negotiation
 ;;

--- a/src/puppetlabs/i18n/main.clj
+++ b/src/puppetlabs/i18n/main.clj
@@ -1,7 +1,9 @@
 (ns puppetlabs.i18n.main
   "Some I18N examples"
   (:gen-class)
-  (:require [puppetlabs.i18n.core :as i18n :refer [tru trs trsn]]))
+  (:require [puppetlabs.i18n.core :as i18n :refer [tru trs trsn mark]]))
+
+(def ^:const const-string (mark "I do not speak German"))
 
 ;; Some simple examples of using tru/trs
 ;; The unit tests rely on the message catalog and translation generated for
@@ -16,6 +18,9 @@
 
   ;; Very simple localization
   (println (trs "Welcome! This is localized"))
+
+  ;; Localizing a previously-extracted string
+  (println (tru const-string))
 
   ;; Very simple plural system localization
   (doseq [beers (range 5 0 -1)]


### PR DESCRIPTION
Previously, the only way to mark a string for extraction was to either
use a translation function or use a project-specific marker function and
update the make target accordingly. This commit provides a standard
i18n/mark function which has no behavior beyond returning its argument,
but which serves as a designated way to extract strings without
translating them.

This is important for cases where the string needs to be translated
dynamically but is defined at compile time. In particular, it allows for
commonly-used strings to be defined in a variables and used in multiple
places.