### PR TITLE
Bolded #3 of Project Setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,10 +114,11 @@ On Red Hat-based operating systems, including Fedora, install gettext via
      You should check these files into you source control system.
    * add hooks to the `compile` task that will refresh i18n data (equivalent of
      running `make i18n`)
-3. If there are namespaces/packages in your project with names which do not
-   start with a prefix derived from the project name, you'll need to list all
-   of your namespaces/package name prefixes in the `PACKAGES` variable in the
-   toplevel `Makefile` before the inclusion of the `dev-resources/Makefile.i18n`
+3. **If there are namespaces/packages in your project with names which do not
+   start with a prefix derived from the project name:** 
+   * you'll need to list all of your namespaces/package name prefixes in the 
+   `PACKAGES` variable in the top level `Makefile` before the inclusion of the 
+   `dev-resources/Makefile.i18n`
 
 This setup will ensure that the file `locales/messages.pot` and the translations
 in `locales/LANG.po` are updated every time you compile your project. Compiling
@@ -218,7 +219,7 @@ The code is set up as an ordinary leiningen project, with the one exception
 that you need to run `make` before running `lein test` or `lein run`, as
 there are messages that need to be turned into a message bundle.
 
-# Maintenance
+# Maintaineance
 
 Maintainers: David Lutterkort <lutter@puppetlabs.com> and Libby Molina <libby@puppetlabs.com>
 Tickets: File bug tickets at https://tickets.puppetlabs.com/browse/INTL, and add the `clj` component to the ticket.

--- a/README.md
+++ b/README.md
@@ -115,10 +115,9 @@ On Red Hat-based operating systems, including Fedora, install gettext via
    * add hooks to the `compile` task that will refresh i18n data (equivalent of
      running `make i18n`)
 3. **If there are namespaces/packages in your project with names which do not
-   start with a prefix derived from the project name:** 
-   * you'll need to list all of your namespaces/package name prefixes in the 
-   `PACKAGES` variable in the top level `Makefile` before the inclusion of the 
-   `dev-resources/Makefile.i18n`
+   start with a prefix derived from the project name:** you'll need to list all 
+   of your namespaces/package name prefixes in the `PACKAGES` variable in the 
+   top level `Makefile` before the inclusion of the `dev-resources/Makefile.i18n`
 
 This setup will ensure that the file `locales/messages.pot` and the translations
 in `locales/LANG.po` are updated every time you compile your project. Compiling

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ The code is set up as an ordinary leiningen project, with the one exception
 that you need to run `make` before running `lein test` or `lein run`, as
 there are messages that need to be turned into a message bundle.
 
-# Maintaineance
+# Maintenance
 
 Maintainers: David Lutterkort <lutter@puppetlabs.com> and Libby Molina <libby@puppetlabs.com>
 Tickets: File bug tickets at https://tickets.puppetlabs.com/browse/INTL, and add the `clj` component to the ticket.


### PR DESCRIPTION
When working on i18n, we were having difficulty with having the translations show up because our namespaces did not match our project name. We read the README multiple times but always ended up glossing over the Project Setup section because our projects already ran smoothly without any errors. I thought that it would be a good idea to change #3 to be in bold font so that more attention can be called to it in case other people encounter this as well.