### PR TITLE
Makefile: fix bashism in target for locales/messages.pot

### DIFF
--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -54,7 +54,7 @@ locales/messages.pot: $(shell $(FIND_SOURCES)) | locales
 	sed -i.bak -e 's/charset=CHARSET/charset=UTF-8/' $$tmp;                 \
 	sed -i.bak -e 's/POT-Creation-Date: [^\\]*/POT-Creation-Date: /' $$tmp; \
 	rm -f $$tmp.bak;                                                        \
-	if ! diff -q -I POT-Creation-Date $$tmp $@ >& /dev/null; then           \
+	if ! diff -q -I POT-Creation-Date $$tmp $@ >/dev/null 2>&1; then        \
 	    mv $$tmp $@;                                                        \
 	else                                                                    \
 	    rm $$tmp; touch $@;                                                 \


### PR DESCRIPTION
We used '>&' which works in bash, but breaks in other shells (like
dash). Instead, use a more standard separate redirection of stdout and
stderr.