### PR TITLE
(PDB-2985) Cache info-map to reduce CPU usage

### DIFF
--- a/dev-resources/test-locales/overlapping-packages.clj
+++ b/dev-resources/test-locales/overlapping-packages.clj
@@ -1,0 +1,8 @@
+;; This is a sample of the locales.clj file that the current version fo the
+;; Makefile generates.
+;; It is used by the tests in core_test.clj.
+{
+  :locales  #{"es"}
+  :packages ["example.i18n.another_package" "example" "example.i18n"]
+  :bundle   "multi_package.i18n.Messages"
+}


### PR DESCRIPTION
This commit switches bundle-for-namespace to use a cached copy of
info-map, rather than regenerating it on each call. Regenerating the
info-map on each translate call and use a lot of CPU and slow down users
of the library.