### PR TITLE
(INTL-7) Revert info-map's usage of sorted-map

### DIFF
--- a/dev-resources/test-locales/overlapping-packages.clj
+++ b/dev-resources/test-locales/overlapping-packages.clj
@@ -3,6 +3,7 @@
 ;; It is used by the tests in core_test.clj.
 {
   :locales  #{"es"}
-  :packages ["example.i18n.another_package" "example" "example.i18n"]
-  :bundle   "multi_package.i18n.Messages"
+  ;; alt3rnate3.i18n has the same length as multi-package-es.clj, dexample.i18n.* overlaps with multi-package-es.clj
+  :packages ["example.i18n.another_package" "example" "example.i18n.another_package" "alt3rnat3.i18n"]
+  :bundle   "overlapped_package.i18n.Messages"
 }

--- a/src/puppetlabs/i18n/core.clj
+++ b/src/puppetlabs/i18n/core.clj
@@ -99,7 +99,7 @@
           (fn [map package]
             (update-in map [package] merge-entry item package))
           map packages)))
-     (sorted-map-by string-length-comparator) (infos))))
+     {} (infos))))
 
 (def info-map
   "Turn the result of infos into a map mapping the package name to
@@ -172,7 +172,7 @@
    (:bundle
     (get i18n-info-map
          (first (filter #(.startsWith namespace %)
-                        (keys i18n-info-map)))))))
+                        (reverse (sort-by count (keys i18n-info-map)))))))))
 
 (defmacro bundle-name
   "Return the name of the ResourceBundle that the trs and tru macros will use"

--- a/test/puppetlabs/i18n/core_test.clj
+++ b/test/puppetlabs/i18n/core_test.clj
@@ -101,7 +101,8 @@
 
 (defn overlapping-pacakge-locale-file
   []
-  [(io/resource "test-locales/overlapping-packages.clj")])
+  [(io/resource "test-locales/overlapping-packages.clj")
+   (io/resource "test-locales/multi-pacakge-es.clj")])
 
 (deftest test-infos
   (with-redefs
@@ -114,8 +115,14 @@
 
   (with-redefs
     [puppetlabs.i18n.core/info-files overlapping-pacakge-locale-file]
-    (testing "info-map with overlapping packages"
-      (is (= ["example.i18n.another_package" "example.i18n" "example"] (keys (info-map'))))))
+    (testing "bundle-for-namespace ordering with overlapping packages and same length namespaces"
+      (are [bundle i18n-ns]
+          (= bundle (bundle-for-namespace (info-map') i18n-ns))
+        "overlapped_package.i18n.Messages" "example"
+        "multi_package.i18n.Messages" "example.i18n"
+        "multi_package.i18n.Messages" "alternate.i18n"
+        "overlapped_package.i18n.Messages" "alt3rnat3.i18n"
+        "overlapped_package.i18n.Messages" "example.i18n.another_package")))
 
   (with-redefs
     [puppetlabs.i18n.core/info-files two-locale-files]


### PR DESCRIPTION
This commit changes the data structure of info-map back to a regular
hash-map. The sorted version was causing problems when two packages had
the same package name length. The sorting now takes place in
bundle-for-namespace, like it did previously.