### PR TITLE
(PE-15457) Scripts for CI POT Update Workflow

### DIFF
--- a/dev-resources/test-pos/diff-location.pot
+++ b/dev-resources/test-pos/diff-location.pot
@@ -1,0 +1,35 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/default.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj, src/puppetlabs/classifier/application/default.clj
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj:666
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj:123, src/puppetlabs/classifier/application/permissioned.clj:456
+msgid "edit classes, variables, and parameters"
+msgstr ""

--- a/dev-resources/test-pos/diff-order.pot
+++ b/dev-resources/test-pos/diff-order.pot
@@ -1,0 +1,36 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit classes, variables, and parameters"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+

--- a/dev-resources/test-pos/diff-ref.pot
+++ b/dev-resources/test-pos/diff-ref.pot
@@ -1,0 +1,35 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit classes, variables, and parameters"
+msgstr ""

--- a/dev-resources/test-pos/diff-string-edit.pot
+++ b/dev-resources/test-pos/diff-string-edit.pot
@@ -1,0 +1,35 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create and delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit classes, variables, and parameters"
+msgstr ""

--- a/dev-resources/test-pos/diff-translated.pot
+++ b/dev-resources/test-pos/diff-translated.pot
@@ -1,0 +1,35 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr "Accedar todas las groupas"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit classes, variables, and parameters"
+msgstr ""

--- a/dev-resources/test-pos/diff-whole-string.pot
+++ b/dev-resources/test-pos/diff-whole-string.pot
@@ -1,0 +1,39 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit classes, variables, and parameters"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "change environment"
+msgstr ""

--- a/dev-resources/test-pos/git-ref.po
+++ b/dev-resources/test-pos/git-ref.po
@@ -1,0 +1,27 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""

--- a/dev-resources/test-pos/line-numbers.po
+++ b/dev-resources/test-pos/line-numbers.po
@@ -1,0 +1,35 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj:123
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj:124, src/puppetlabs/classifier/application/permissioned.clj:836
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "src/foo.clj:340"
+msgstr ""

--- a/dev-resources/test-pos/no-git-ref.po
+++ b/dev-resources/test-pos/no-git-ref.po
@@ -1,0 +1,26 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""

--- a/dev-resources/test-pos/no-line-numbers.po
+++ b/dev-resources/test-pos/no-line-numbers.po
@@ -1,0 +1,35 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: puppetlabs.classifier \n"
+"X-Git-Ref: deadb33f\n"
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj, src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "edit parameter values"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "src/foo.clj:340"
+msgstr ""

--- a/dev-resources/test-pos/no-project-id-version.po
+++ b/dev-resources/test-pos/no-project-id-version.po
@@ -1,0 +1,25 @@
+# Esperanto test translations for puppetlabs.classifier package.
+# Copyright (C) 2016 Puppet Labs <docs@puppetlabs.com>
+# This file is distributed under the same license as the puppetlabs.classifier package.
+# Automatically generated, 2016.
+#
+msgid ""
+msgstr ""
+"Report-Msgid-Bugs-To: docs@puppet.com\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: Automatically generated\n"
+"Language-Team: none\n"
+"Language: eo\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "access all groups"
+msgstr ""
+
+#: src/puppetlabs/classifier/application/permissioned.clj
+msgid "create or delete children"
+msgstr ""

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
 
   :pedantic? :abort
   :dependencies [[org.clojure/clojure "1.6.0"]
+                 [cpath-clj "0.1.2"]
                  [org.gnu.gettext/libintl "0.18.3"]]
 
   :profiles {:dev {:dependencies [[puppetlabs/kitchensink "2.1.0"

--- a/project.clj
+++ b/project.clj
@@ -8,6 +8,9 @@
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.gnu.gettext/libintl "0.18.3"]]
 
+  :profiles {:dev {:dependencies [[puppetlabs/kitchensink "2.1.0"
+                                   :exclusions [org.clojure/clojure]]]}}
+
   :main puppetlabs.i18n.main
   :aot [puppetlabs.i18n.main]
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/i18n "0.4.4-SNAPSHOT"
+(defproject puppetlabs/i18n "0.5.0-SNAPSHOT"
   :description "Clojure i18n library"
   :url "http://github.com/puppetlabs/clj-i18n"
   :license {:name "Apache License, Version 2.0"

--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -35,7 +35,7 @@ endef
 export LOCALES_CLJ_CONTENTS
 
 
-i18n: update-pot msgfmt
+i18n: msgfmt
 
 # Update locales/messages.pot
 update-pot: locales/messages.pot

--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -85,12 +85,11 @@ resources/$(BUNDLE_DIR)/Messages_%.class: locales/%.po | resources
 resources/$(BUNDLE_DIR)/Messages_$(MESSAGE_LOCALE).class: locales/messages.pot | resources
 	msgfmt --java2 -d resources -r $(BUNDLE).Messages -l $(MESSAGE_LOCALE) $<
 
-# Translators use this when they update translations; this copies any
-# changes in the pot file into their language-specific po file
-locales/%.po: locales/messages.pot
-	@if [ -f $@ ]; then                                           \
-	    msgmerge -U $@ $< && touch $@;                            \
-	else                                                          \
+# Use this to initialize translations. Updating the PO files is done
+# automatically through a CI job that utilizes the scripts in the project's
+# `bin` file, which themselves come from the `clj-i18n` project.
+locales/%.po: | locales
+	@if [ ! -f $@ ]; then                                         \
 	    touch $@ && msginit --no-translator -l $(*F) -o $@ -i $<; \
 	fi
 
@@ -118,7 +117,7 @@ You can use the following targets:
 
   i18n:             refresh all the files in locales/ and recompile resources
   update-pot:       extract strings and update locales/messages.pot
-  locales/LANG.po:  refresh or create translations for LANG
+  locales/LANG.po:  create translations for LANG
   msgfmt:           compile the translations into Java classes; this step is
                     needed to make translations available to the Clojure code
                     and produces Java class files in resources/

--- a/src/leiningen/i18n/bin/add-gitref.sh
+++ b/src/leiningen/i18n/bin/add-gitref.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+# This script does one thing and one thing only: given a PO or POT filename, it
+# adds a 'X-Git-Ref' header (or updates the existing header) with the current
+# git HEAD's SHA. If it can't add the header for any reason, it prints a message
+# on stderr and exits nonzero.
+#
+# All of the real work is just a few lines in the addAfterLine and addGitSha
+# functions; the rest of the script is checking for error conditions.
+
+FIELD_NAME='X-Git-Ref'
+PREVIOUS_FIELD='Project-Id-Version'
+COMMIT_HEADER_REGEX="^\"$FIELD_NAME:[ \t]*[a-zA-Z0-9]*[ \t]*\\\\n\"[ \t]*$"
+
+function addAfterLine { # filename target_line new_line
+  local file="$1" target_line="$2" new_line="$3"
+  sed -i.bak -e "/^$target_line\s*$/ {" -e "a\\
+$new_line" -e "}" "$file"
+  rm "$file.bak"
+}
+
+function addGitSha { # POx_file
+  local pot_file="$1" sha=$(git rev-parse HEAD)
+  addAfterLine "$pot_file" "\\\"$PREVIOUS_FIELD:.*\\\"" "\"$FIELD_NAME: $sha\\\\n\""
+}
+
+## Main
+## ====
+
+set -eo pipefail
+
+pot_file="$1"
+
+set -u # there should be no more undefined variables
+
+if [[ -z "$pot_file" ]]; then
+  echo "ERROR: no PO or POT file given" 1>&2
+  echo "usage: $0 <po-or-pot-file>" 1>&2
+  exit 1
+fi
+
+if [[ ! -e "$pot_file" ]]; then
+  echo "ERROR: the file '$pot_file' does not exist" 1>&2
+  exit 1
+fi
+
+if [[ ! -r "$pot_file" ]]; then
+  echo "ERROR: don't have permission to open file '$pot_file'" 1>&2
+  exit 1
+fi
+
+## if there's a commit header in there already, remove it
+if [[ ! -z "$(grep "$COMMIT_HEADER_REGEX" "$pot_file")" ]]; then
+  sed -i.bak -e "/$COMMIT_HEADER_REGEX/ {" -e d -e "}" "$pot_file"
+  rm "$pot_file.bak"
+fi
+
+if ! grep "$PREVIOUS_FIELD" "$pot_file"; then
+  echo "ERROR: the $FIELD_NAME header must follow the $PREVIOUS_FIELD header, but no" 1>&2;
+  echo "$PREVIOUS_FIELD header was found in '$pot_file'" 1>&2;
+  exit 1
+fi
+
+addGitSha "$pot_file"
+
+if ! grep "$FIELD_NAME" "$pot_file"; then
+  echo "ERROR: unable to add $FIELD_NAME header to '$pot_file' for unknown reasons." 1>&2;
+  echo "Please file a bug report." 1>&2;
+  exit 1
+fi

--- a/src/leiningen/i18n/bin/compare-POTs.sh
+++ b/src/leiningen/i18n/bin/compare-POTs.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# This script's only function is to determine whether there are any differences
+# in the strings of the two gettext PO or POT files it's given as arguments. If
+# there are no differences, a message to that effect is printed and the script
+# exits zero; if there are, a different message is printed and the exit status
+# is nonzero (specifically, 1),
+#
+# Differences are defined as only the addition or removal of entire strings
+# and changes to the content of any one string; any differences in the
+# translations available between the two files does not count.
+#
+# Most of this scritp is just checking error conditions; the real work happens
+# in the last 10 lines.
+
+set -eo pipefail
+
+usage="usage: $0 old.pot new.pot"
+
+old="$1"
+new="$2"
+
+set -u # there should be no more undefined variables
+
+if [[ -z "$old" ]]; then
+  echo "ERROR: no 'old.pot' file given" 1>&2
+  echo "$usage" 1>&2
+  exit 1
+fi
+
+if [[ -z "$new" ]]; then
+  echo "ERROR: no 'new.pot' file given" 1>&2
+  echo "$usage" 1>&2
+  exit 1
+fi
+
+for f in "$old" "$new"; do
+  if [[ ! -e "$f" ]]; then
+    echo "ERROR: the file '$f' does not exist" 1>&2;
+    exit 1
+  fi
+
+  if [[ ! -r "$f" ]]; then
+    echo "ERROR: don't have permission to open $f" 1>&2;
+    exit 1
+  fi
+done
+
+set +e # msgcmp will return 1 if there are any differences
+msgcmp_warnings=$(msgcmp --use-untranslated "$old" "$new" 2>&1)
+msgcmp_status=$?
+set -e
+
+set -x
+
+if [[ "$msgcmp_status" -ne 0 \
+      || "$msgcmp_warnings" =~ "warning: this message is not used" ]]; then
+  echo "Found differences between the POTs"
+  exit 1
+else
+  echo "The POTs contain identical strings"
+  exit 0
+fi

--- a/src/leiningen/i18n/bin/remove-line-numbers.sh
+++ b/src/leiningen/i18n/bin/remove-line-numbers.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# This script's only function is to strip the line numbers from the location
+# comments in a PO or POT file. It does this using a sed one-liner at the
+# bottom. The preceding lines are largely about checking for error conditions.
+
+set -eo pipefail
+
+gettext_file="$1"
+
+set -u # there should be no more undefined variables
+
+if [[ -z "$gettext_file" ]]; then
+  echo "ERROR: no PO or POT file given" 1>&2
+  echo "usage: $0 <PO-or-POT-file>" 1>&2
+  exit 1
+fi
+
+if [[ ! -e "$gettext_file" ]]; then
+  echo "ERROR: the file '$gettext_file' does not exist" 1>&2
+  exit 1
+fi
+
+if [[ ! -r "$gettext_file" ]]; then
+  echo "ERROR: don't have permission to open '$gettext_file'" 1>&2
+  exit 1
+fi
+
+sed -i.bak -e '/^#:.*[0-9]/ {' -e 's/:[0-9][0-9]*//g' -e '}' "$gettext_file"
+rm "$gettext_file.bak"

--- a/src/leiningen/i18n/bin/update-pot.sh
+++ b/src/leiningen/i18n/bin/update-pot.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -eo pipefail
+
+repo_dir="$(realpath "$(dirname "$0")/../../..")"
+pot_file="$repo_dir/locales/messages.pot"
+compare_pots="$repo_dir/dev-resources/i18n/bin/compare-POTs.sh"
+
+git_branch="$1";
+
+set -u
+
+if [[ -z "$git_branch" ]]; then
+  echo "ERROR: no git branch argument was supplied, so the updated POT can't be pushed" 1>&2
+  echo "usage: $0 remote_branch_name" 1>&2
+  exit 1
+fi
+
+if [[ ! -e "$pot_file" ]]; then
+  echo "ERROR: POT file '$pot_file' doesn't exist" 1>&2
+  echo 'Have you run `make i18n update-pot`?'
+  exit 1
+fi
+
+if [[ ! -r "$pot_file" ]]; then
+  echo "ERROR: don't have permission to open '$pot_file'" 1>&2
+  exit 1
+fi
+
+if [[ ! -e "$compare_pots" ]]; then
+  echo "ERROR: the file '$compare_pots' does not exist" 1>&2
+  echo 'Have you run 'lein i18n init'?' 1>&2
+  exit 1
+fi
+
+if [[ ! -x "$compare_pots" ]]; then
+  echo "ERROR: don't have permission to execute '$compare_pots'" 1>&2
+  exit 1
+fi
+
+# move current POT out of the way
+old_pot="$(mktemp "/tmp/i18n-POT-XXXXXXXX.po")"
+mv "$pot_file" "$old_pot"
+
+# regenerate the POT
+make update-pot
+new_pot="$pot_file"
+
+echo ""
+echo "Comparing checked-in POT file with fresh POT file"
+
+set +e
+# see if there are new strings in the new POT
+if ! "$compare_pots" "$old_pot" "$new_pot"; then
+  set -e
+
+  echo ""
+  echo "String changes found in fresh POT file; committing"
+
+  ./dev-resources/i18n/bin/remove-line-numbers.sh "$new_pot"
+  ./dev-resources/i18n/bin/add-gitref.sh "$new_pot"
+
+  git add "$new_pot"
+  git commit -m "(i18n) Update strings in messages.pot file"
+
+  echo ""
+  echo "Pushing updated POT file to GitHub"
+
+  git push origin "HEAD:$git_branch"
+
+  rm "$old_pot"
+else
+  echo ""
+  echo "No string changes found; restoring old POT file"
+  mv "$old_pot" "$pot_file"
+fi
+
+

--- a/test/puppetlabs/i18n/bin_test.clj
+++ b/test/puppetlabs/i18n/bin_test.clj
@@ -58,3 +58,16 @@
         (is (re-find #"X-Git-Ref\s+header\s+must\s+follow\s+the\s+Project-Id-Version" err))
         (is (re-find #"no\s+Project-Id-Version\s+header\s+was\s+found" err))
         (is (re-find (re-pattern (path po)) err))))))
+
+(deftest remove-line-numbers-test
+  (testing "the remove-line-numbers.sh script behaves as expected"
+    (let [numbered-po (temp-file-from-resource "i18n-rm-line-nos-test" ".po"
+                                               "test-pos/line-numbers.po")
+          proc (sh "src/leiningen/i18n/bin/remove-line-numbers.sh"
+                   (path numbered-po))]
+      (is (zero? (:exit proc)))
+      (let [post-script-contents (slurp numbered-po)]
+        (is (= post-script-contents
+               (-> (io/resource "test-pos/no-line-numbers.po")
+                 io/file
+                 slurp)))))))

--- a/test/puppetlabs/i18n/bin_test.clj
+++ b/test/puppetlabs/i18n/bin_test.clj
@@ -1,0 +1,60 @@
+(ns puppetlabs.i18n.bin-test
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.test :refer :all]
+            [clojure.java.shell :refer [sh]]
+            [puppetlabs.kitchensink.core :as ks]))
+
+(defn git-head-sha
+  []
+  (-> (sh "git" "rev-parse" "HEAD")
+    :out
+    str/trim))
+
+(defn temp-file-from-resource
+  "Given a prefix & suffix for a temp filename, and the classpath of a Java
+  resource, create a new temp file with the resource's content that will be
+  deleted when the JVM shuts down. Returns a File object for the temp file."
+  [prefix suffix resource-path]
+  (let [temp-file (ks/temp-file prefix suffix)
+        resource (io/resource resource-path)]
+    (io/copy (io/file resource) temp-file)
+    temp-file))
+
+(defn- path [f] (.getPath f))
+
+(deftest add-gitref-test
+  (testing "the src/leiningen/i18n/bin/add-gitref.sh script"
+    (let [current-git-ref-line (re-pattern (str "\n\"X-Git-Ref: "
+                                                (git-head-sha)
+                                                "\\\\n\"\\s*\n"))]
+
+      (testing "adds a git ref header when none is present"
+        (let [po (temp-file-from-resource "i18n-add-gitref-test" ".po"
+                                          "test-pos/no-git-ref.po")
+              proc (sh "src/leiningen/i18n/bin/add-gitref.sh"
+                       (path po))]
+          (is (zero? (:exit proc)))
+          (is (re-find current-git-ref-line (slurp po)))))
+
+      (testing "replaces git ref header when one is already present"
+        (let [fake-git-ref-line  #"\n\"X-Git-Ref: deadb33f\\n\""
+              po (temp-file-from-resource "i18n-add-gitref-test" ".po"
+                                          "test-pos/git-ref.po")
+              _ (is (re-find fake-git-ref-line (slurp po)))
+              proc (sh "src/leiningen/i18n/bin/add-gitref.sh"
+                       (path po))]
+          (is (zero? (:exit proc)))
+          (let [post-script-contents (slurp po)]
+            (is (re-find current-git-ref-line post-script-contents))
+            (is (nil? (re-find fake-git-ref-line post-script-contents)))))))
+
+    (testing "when given a PO file without a Project-Id-Version header"
+      (let [po (temp-file-from-resource "i18n-add-gitref-test" ".po"
+                                        "test-pos/no-project-id-version.po")
+            {:keys [exit err]} (sh "src/leiningen/i18n/bin/add-gitref.sh"
+                                   (path po))]
+        (is (= 1 exit))
+        (is (re-find #"X-Git-Ref\s+header\s+must\s+follow\s+the\s+Project-Id-Version" err))
+        (is (re-find #"no\s+Project-Id-Version\s+header\s+was\s+found" err))
+        (is (re-find (re-pattern (path po)) err))))))


### PR DESCRIPTION
These commits add several scripts that facilitate automated updates of the `locals/messages.POT` file in CI. The main script is `src/leiningen/i18n/bin/update-pot.sh`, which moves the current POT out of the way, generates a new one, compares the strings between the two, and commits and pushes the new POT if it has different strings than the old one (after stripping any line numbers from the location comments and adding a header with the current git commit's SHA). If no string changes are found, the extant POT is restored.

This main script has no automated tests, but most of the work happens in the other scripts, all of which have clojure tests for their behavior in the `puppetlabs.i18n.bin-test` namespace. The main script has been tested by using it in an experimental CI job on Jenkins Enterprise and observing that it succeeded and succesfully pushed [this commit updating the POT](https://github.com/puppetlabs/classifier/commit/cf48c8d5489cd3502046472c9d268da8517b235b) to GitHub.

All of these scripts are copied to the target project's `dev-resources/i18n/bin` directory during the `i18n init` lein task, and that directory is added to the target project's gitignore file.

This includes a commit that changes `dev-resources/Makefile.i18n`  to no longer update any PO files in the `locales` directory, since those will be exclusively managed by Transifex's GitHub integration.

Given the above behavior change, and the new functionality, this also bumps the version to `0.5.0-SNAPSHOT`