### PR TITLE
(maint) Don't use `realpath` in update-pot script

### DIFF
--- a/src/leiningen/i18n/bin/update-pot.sh
+++ b/src/leiningen/i18n/bin/update-pot.sh
@@ -2,7 +2,7 @@
 
 set -eo pipefail
 
-repo_dir="$(realpath "$(dirname "$0")/../../..")"
+repo_dir="$(dirname "$0")/../../.."
 pot_file="$repo_dir/locales/messages.pot"
 compare_pots="$repo_dir/dev-resources/i18n/bin/compare-POTs.sh"
 


### PR DESCRIPTION
It appears that [`realpath` is not uniformly available on our jenkins test runners](https://jenkins-enterprise.delivery.puppetlabs.net/job/enterprise_rbac_i18n-clj_2017.1.x/1/console).