### PR TITLE
(PE-18855) Default the user-locale to system-locale

### DIFF
--- a/src/puppetlabs/i18n/core.clj
+++ b/src/puppetlabs/i18n/core.clj
@@ -311,7 +311,7 @@
   in wanted that is available, and return the corresponding Locale object.
 
   This function will always return a locale. If we can't negotiate a
-  suitable locale, we fall back to the message-locale"
+  suitable locale, we fall back to the system-locale"
   [wanted available]
   ;; @todo lutter 2015-05-20: if wanted contains only a country-specific
   ;; variant, and we have the general variant, we might want to match those
@@ -323,7 +323,7 @@
   ;; falling back to the message locale
   (if-let [loc (some available wanted)]
     (string-as-locale loc)
-    (message-locale)))
+    (system-locale)))
 
 (defn locale-negotiator
   "Ring middleware that performs locale negotiation.

--- a/test/puppetlabs/i18n/core_test.clj
+++ b/test/puppetlabs/i18n/core_test.clj
@@ -184,7 +184,7 @@
 
 (deftest test-negotiate-locale
   (with-redefs
-    [puppetlabs.i18n.core/message-locale #(string-as-locale "oc")]
+    [puppetlabs.i18n.core/system-locale #(string-as-locale "oc")]
     (let [check
           (fn [exp wanted]
             (is (= (string-as-locale exp)
@@ -204,7 +204,7 @@
 (deftest test-locale-negotiator
   (with-redefs
     [puppetlabs.i18n.core/available-locales (fn [] #{"de" "fr-FR" "en"})
-     puppetlabs.i18n.core/message-locale #(string-as-locale "oc")]
+     puppetlabs.i18n.core/system-locale #(string-as-locale "oc")]
     (let [neg        (locale-negotiator (fn [request] (user-locale)))
           mk-request (fn [accept]
                        {:headers {"accept-language" accept}})
@@ -215,10 +215,10 @@
         (check "de" "de")
         (check "de" "de_DE, de;q=0.9, en;q=0.8")
         (check "oc" "it, fr"))
-      (testing "falls back to message-locale for empty/invalid headers"
+      (testing "falls back to system-locale for empty/invalid headers"
         (map #(check "oc" %) ["" nil "en;q=garbage" ",,," ",;," "xyz" "de-US"])
-        (is (= (message-locale) (neg {:headers {}})))
-        (is (= (message-locale) (neg {}))))
+        (is (= (system-locale) (neg {:headers {}})))
+        (is (= (system-locale) (neg {}))))
       (testing "conveys the locale"
         (is (= (string-as-locale "de")
                ((locale-negotiator (fn [request] @(future (user-locale))))


### PR DESCRIPTION
Prior to this commit we were defaulting the user-locale to message-locale
(i.e. "en"). This commit changes this behavior so that we default to
translating `i18n/tru` messages to system-locale translations if we have
them.