### PR TITLE
(maint) Prepare for 0.6.0 release

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/i18n "0.5.2-SNAPSHOT"
+(defproject puppetlabs/i18n "0.6.0-SNAPSHOT"
   :description "Clojure i18n library"
   :url "http://github.com/puppetlabs/clj-i18n"
   :license {:name "Apache License, Version 2.0"


### PR DESCRIPTION
This commit prepares the project.clj for a 0.6.0 release.