### PR TITLE
(PE-19745) Empty string should render an empty string not POT header.

### DIFF
--- a/src/puppetlabs/i18n/core.clj
+++ b/src/puppetlabs/i18n/core.clj
@@ -200,7 +200,7 @@
   contain an entry for msg, return msg itself"
   [namespace loc msg]
   (let [bundle (get-bundle namespace loc)]
-    (if bundle
+    (if (and bundle (not-empty msg))
       (try
         (gnu.gettext.GettextResource/gettext bundle msg)
         (catch java.util.MissingResourceException e
@@ -214,7 +214,7 @@
   contain an entry for msg, return msg itself"
   [namespace loc msgid msgid-plural count]
   (let [bundle (get-bundle namespace loc)]
-    (if bundle
+    (if (and bundle (not-empty msgid))
       (try
         (gnu.gettext.GettextResource/ngettext bundle msgid msgid-plural count)
         (catch java.util.MissingResourceException e

--- a/src/puppetlabs/i18n/main.clj
+++ b/src/puppetlabs/i18n/main.clj
@@ -1,7 +1,7 @@
 (ns puppetlabs.i18n.main
   "Some I18N examples"
   (:gen-class)
-  (:require [puppetlabs.i18n.core :as i18n :refer [tru trs trsn mark]]))
+  (:require [puppetlabs.i18n.core :as i18n :refer [tru trs trun trsn mark]]))
 
 (def ^:const const-string (mark "I do not speak German"))
 
@@ -21,6 +21,28 @@
 
   ;; Localizing a previously-extracted string
   (println (tru const-string))
+
+  ;; Localizing an empty string
+  (println (tru ""))
+  (println "-----")
+  (println (trs ""))
+  (println "-----")
+  (println (trun "" "" 1))
+  (println "-----")
+  (println (trun "" "" 6))
+  (println "-----")
+  (println (trun "" "non empty string" 1))
+  (println "-----")
+  (println (trun "non empty string" "" 6))
+  (println "-----")
+  (println (trsn "" "" 1))
+  (println "-----")
+  (println (trsn "" "" 6))
+  (println "-----")
+  (println (trsn "" "non empty string" 1))
+  (println "-----")
+  (println (trsn "non empty string" "" 6))
+  (println "-----")
 
   ;; Very simple plural system localization
   (doseq [beers (range 5 0 -1)]

--- a/test/puppetlabs/i18n/core_test.clj
+++ b/test/puppetlabs/i18n/core_test.clj
@@ -9,6 +9,8 @@
 
 (def de (string-as-locale "de-DE"))
 (def eo (string-as-locale "eo"))
+(def en (string-as-locale "en-US"))
+
 (def welcome_en "Welcome! This is localized")
 (def welcome_de "Willkommen ! Draußen nur Kännchen")
 (def welcome_eo "Welcome_pseudo_localized")
@@ -20,7 +22,6 @@
 
 (def six_bottle_en "There are 6 bottles of beer on the wall.")
 (def six_bottle_de "Es gibt 6 Flaschen Bier an der Wand.")
-
 
 (deftest handling-of-user-locale
   (testing "user-locale defaults to system-locale"
@@ -64,13 +65,49 @@
 
 
 (deftest test-trsn
-  (testing "trun with no user locale"
+  (testing "trsn with no user locale"
     (is (= one_bottle_en (trsn one_bottle n_bottles 1)))
     (is (= six_bottle_en (trsn one_bottle n_bottles 6))))
-  (testing "trun with a user locale"
+  (testing "trsn with a user locale"
     (with-user-locale de (is (= one_bottle_en (trsn one_bottle n_bottles 1))))
     (with-user-locale de (is (= six_bottle_en (trsn one_bottle n_bottles 6))))))
 
+
+(deftest test-empty-string-msgid-fallback-to-pot-no-header
+  (testing "trsn with no user locale"
+      (is (= "" (trsn "" "" 1)))
+      (is (= "" (trsn "" "" 6)))
+      (is (= "" (trsn "" "fred" 1)))
+      (is (= "fred" (trsn "" "fred" 6)))
+      ; msgid/msgstr not in po/bundle render correctly
+      (is (= "fred" (trsn "fred" "" 1)))
+      (is (= "" (trsn "fred" "" 6))))
+  (testing "trsn with a user locale"
+      (with-user-locale de
+        (is (= "" (trsn "" "" 1)))
+        (is (= "" (trsn "" "" 6)))
+        (is (= "" (trsn "" "fred" 1)))
+        (is (= "fred" (trsn "" "fred" 6)))
+        ; msgid/msgstr not in po/bundle render correctly
+        (is (= "fred" (trsn "fred" "" 1)))
+        (is (= "" (trsn "fred" "" 6)))))
+  (testing "trun can display an empty string"
+    (with-user-locale de
+      (is (= "" (trun "" "" 1)))
+      (is (= "" (trun "" "" 6)))
+      (is (= "" (trun "" "fred" 1)))
+      (is (= "fred" (trun "" "fred" 6)))
+      ; msgid/msgstr not in po/bundle render correctly
+      (is (= "fred" (trun "fred" "" 1)))
+      (is (= "" (trun "fred" "" 6)))))
+  (testing "trs can display an empty string"
+    (with-user-locale de
+      (is (= "" (trs "")))
+      (is (= " " (trs " ")))))
+  (testing "tru can display an empty string"
+    (with-user-locale de
+      (is (= "" (tru "")))
+      (is (= " " (tru " "))))))
 ;;
 ;; Helper files in dev-resources; they have the same format as the
 ;; locales.clj file that the Makefile generates


### PR DESCRIPTION
Prior to this commit, if a string was empty, instead of an empty string in the class bundle, GNU gettext behavior is to print the header of the POT file. So where we would expect empty strings, the POT header would be printed instead.

With this commit if a msgid is an empty string, an empty string is returned.