### PR TITLE
(maint) only format when there are arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ On Red Hat-based operating systems, including Fedora, install gettext via
 
 [![Clojars Project](https://img.shields.io/clojars/v/puppetlabs/i18n.svg)](https://clojars.org/puppetlabs/i18n)
 
-1. In your `project.clj`, add `[puppetlabs/i18n "0.5.0"]` to your project's
+1. In your `project.clj`, add `[puppetlabs/i18n "0.8.0"]` to your project's
    :plugins and :dependencies vectors (without the version number in
    :dependencies if your project uses clj-parent). Also add
    ```

--- a/locales/de.po
+++ b/locales/de.po
@@ -21,6 +21,11 @@ msgstr ""
 msgid "I do not speak German"
 msgstr "Ich spreche kein Deutsch"
 
+#. simple string formatting demonstration
+#: src/puppetlabs/i18n/main.clj
+msgid "{0} and {1} walked up the hill."
+msgstr "{0} und {1} gingen den Hügel hinauf."
+
 #. Very simple localization
 #: src/puppetlabs/i18n/main.clj
 msgid "Welcome! This is localized"
@@ -42,3 +47,4 @@ msgstr "In Peking gibt es {0,number,integer} Fahrräder"
 
 #~ msgid "This is another test string"
 #~ msgstr "german german german german german"
+

--- a/locales/messages.pot
+++ b/locales/messages.pot
@@ -3,9 +3,12 @@
 # This file is distributed under the same license as the puppetlabs.i18n package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
+#. Localizing an empty string
+#: src/puppetlabs/i18n/main.clj
 #, fuzzy
 msgid ""
-msgstr ""
+msgid_plural ""
+msgstr[0] ""
 "Project-Id-Version: puppetlabs.i18n \n"
 "Report-Msgid-Bugs-To: docs@puppet.com\n"
 "POT-Creation-Date: \n"
@@ -39,4 +42,9 @@ msgstr ""
 
 #: src/puppetlabs/i18n/main.clj
 msgid "There are {0,number,integer} bicycles in Beijing"
+msgstr ""
+
+#. simple string formatting demonstration
+#: src/puppetlabs/i18n/main.clj
+msgid "{0} and {1} walked up the hill."
 msgstr ""

--- a/src/puppetlabs/i18n/core.clj
+++ b/src/puppetlabs/i18n/core.clj
@@ -254,7 +254,10 @@
   needed. Messages are looked up in the resource bundle associated with the
   given namespace"
   [namespace loc msg & args]
-  (fmt loc (lookup namespace loc msg) (to-array args)))
+  (let [translated (lookup namespace loc msg)]
+    (if (nil? args)
+      translated
+      (fmt loc translated (to-array args)))))
 
 (defn translate-plural
   "Translate a message into the given locale, interpolating as

--- a/src/puppetlabs/i18n/main.clj
+++ b/src/puppetlabs/i18n/main.clj
@@ -19,6 +19,9 @@
   ;; Very simple localization
   (println (trs "Welcome! This is localized"))
 
+  ;; simple string formatting demonstration
+  (println (trs "{0} and {1} walked up the hill." "Jack" "Jill"))
+
   ;; Localizing a previously-extracted string
   (println (tru const-string))
 

--- a/test/puppetlabs/i18n/core_test.clj
+++ b/test/puppetlabs/i18n/core_test.clj
@@ -38,10 +38,17 @@
 
 (deftest test-tru
   (testing "tru with no user locale"
-    (is (= welcome_en (tru welcome_en))))
+    (is (= welcome_en (tru welcome_en)))
+    (is (= "Fred and George walked up the hill." (tru "{0} and {1} walked up the hill." "Fred" "George")))
+    ; if formatting is really applied, the result comes back without the date formatting hint
+    (is (= "Fake formatted string {0, date}" (tru "Fake formatted string {0, date}"))))
+
   (testing "tru in German"
     (with-user-locale de
-      (is (= welcome_de (tru welcome_en)))))
+      (is (= welcome_de (tru welcome_en)))
+      (is (= "Fred und George gingen den Hügel hinauf."
+             (tru "{0} and {1} walked up the hill." "Fred" "George")))))
+
   (testing "tru in Esperanto"
     ;; We use Esperanto as our test locale
     (with-user-locale eo
@@ -58,11 +65,15 @@
 
 (deftest test-trs
   (testing "trs with no user locale"
-    (is (= welcome_en (trs welcome_en))))
+    (is (= welcome_en (trs welcome_en)))
+    (is (= "Formatted string zero one two" (trs "Formatted string {0} {1} {2}" "zero" "one" "two")))
+    ; if formatting is really applied, the result comes back without the date formatting hint
+    (is (= "Fake formatted string {0, date}" (trs "Fake formatted string {0, date}"))))
   (testing "trs with a user locale"
     (with-user-locale de
-      (is (= welcome_en (trs welcome_en))))))
-
+      (is (= welcome_en (trs welcome_en)))
+      (is (= "Fred and George walked up the hill."
+             (trs "{0} and {1} walked up the hill." "Fred" "George"))))))
 
 (deftest test-trsn
   (testing "trsn with no user locale"


### PR DESCRIPTION
For a translation where there are no formatting arguments, add a
simple check to avoid formatting the string.  This avoids
the creation of a message format object, and avoids calling the
format function for things that will never benefit from it.