### PR TITLE
(maint) Only delete bundle if it exists

### DIFF
--- a/src/leiningen/i18n/Makefile
+++ b/src/leiningen/i18n/Makefile
@@ -85,7 +85,7 @@ $(LOCALES_CLJ): | resources
 clean-orphaned-bundles:
 	@for bundle in resources/$(BUNDLE_DIR)/Messages_*.class; do                                  \
 	  locale=$$(basename "$$bundle" | sed -E -e 's/\$$?1?\.class$$/_class/' | cut -d '_' -f 2;); \
-	  if [ ! -f "locales/$$locale.po" ]; then                                                    \
+	  if [ ! -f "locales/$$locale.po" -a -f "$$bundle" ]; then                                                    \
 	    rm "$$bundle";                                                                           \
 	  fi                                                                                         \
 	done


### PR DESCRIPTION
On initial bootstrapping of i18n it seems like the
clean-orphaned-bundles can get into a state where it tries to remove a
glob that doesn't exist. I think fixing the glob behavior would be
ideal, but as I don't have a good idea about that this commit adds a
check to see if the bundle exists before attempting to delete it.

```matthaus@wyclef-2  /Users/matthaus/src/pe-file-sync [hoyt]> lein i18n init
Setting up Makefile; don't forget to check it in
Adding i18n scripts in `dev-resources/i18n/bin`
matthaus@wyclef-2  /Users/matthaus/src/pe-file-sync [hoyt]> make i18n
Writing resources/locales.clj
matthaus@wyclef-2  /Users/matthaus/src/pe-file-sync [hoyt]> make i18n
rm: resources/puppetlabs/pe_file_sync/Messages_*.class: No such file or directory
make: *** [clean-orphaned-bundles] Error 1```