### PR TITLE
(maint) remove AOT compilation and main clause from project.clj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [0.9.1]
+
+- remove AOT and main specification from jar to make artifact more portable.
+- remove main specification in project.clj and update README with new example.

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ which a huge amount of tooling exists.
 The `main.clj` and `example/program` in this repo contain some simple code
 that demonstrates how to use the translation functions. Before you can use
 it, you need to run `make` to generate the necessary
-`ResourceBundles`. After that, you can use `lein run` or `LANG=de_DE lein
-run` to look at English and German output.
+`ResourceBundles`. After that, you can use `lein run -m puppetlabs.i18n.main`
+or `LANG=de_DE lein run -m puppetlabs.i18n.main` to look at English and German output.
 
 ## Developer usage
 

--- a/project.clj
+++ b/project.clj
@@ -12,9 +12,6 @@
   :profiles {:dev {:dependencies [[puppetlabs/kitchensink "2.1.0"
                                    :exclusions [org.clojure/clojure]]]}}
 
-  :main puppetlabs.i18n.main
-  :aot [puppetlabs.i18n.main]
-
   :deploy-repositories [["releases" {:url "https://clojars.org/repo"
                                      :username :env/clojars_jenkins_username
                                      :password :env/clojars_jenkins_password


### PR DESCRIPTION
In order to make the library more portable, this removes the AOT
specification for main, and the main entry in the project.clj

The README is updated with instructions to correctly run the
main example.

A CHANGELOG is also added to provide a brief summary of changes going forward.